### PR TITLE
Unescape Uri AbsolutePath

### DIFF
--- a/jni4net.n/src/Bridge.cs
+++ b/jni4net.n/src/Bridge.cs
@@ -136,7 +136,7 @@ namespace net.sf.jni4net
                 return jar4;
             }
 
-            dir = Path.GetDirectoryName(new Uri(typeof(Bridge).Assembly.GetName().CodeBase).AbsolutePath);
+            dir = Path.GetDirectoryName(Uri.UnescapeDataString(new Uri(typeof(Bridge).Assembly.GetName().CodeBase).AbsolutePath));
             var jar5 = Path.GetFullPath(Path.Combine(dir, jarName));
             if (System.IO.File.Exists(jar5))
             {


### PR DESCRIPTION
It fixes looking for jni4net.j-0.8.8.0.jar in paths with spaces, % or some other characters. Without unescaping the path may be invalid.