### PR TITLE
Update Bridge.cs

### DIFF
--- a/jni4net.n/src/Bridge.cs
+++ b/jni4net.n/src/Bridge.cs
@@ -274,6 +274,11 @@ namespace net.sf.jni4net
             }
         }
 
+        public static void ReregisterAssembly(Assembly assembly, ClassLoader classLoader) {
+
+            Registry.RegisterAssembly(assembly, true, classLoader, true);
+        }
+
         public static void SetSystemClassLoader(ClassLoader classLoader)
         {
             Registry.systemClassLoader = classLoader;


### PR DESCRIPTION
The new method allows me to reregister the Bridge's Assembly under a new class loader (see changes to Registry.register.cs as well).  I'm having to call into a war file that has several class loaders / threads.  This change got me working, but I understand that it is a little bit of a hack, so I'm not proposing that this be the final solution for public consumption.