### PR TITLE
Fixed CLRName. $ sign is allowed in Java for  but not allowed in C#. …

### DIFF
--- a/jni4net.proxygen/src/model/GMethod.cs
+++ b/jni4net.proxygen/src/model/GMethod.cs
@@ -44,7 +44,14 @@ namespace net.sf.jni4net.proxygen.model
         public bool UseExplicitInterface { get; set; }
         public GType DeclaringType { get; set; }
         public string JVMName { get; set; }
-        public string CLRName { get; set; }
+
+        private string _clrName;
+        public string CLRName
+        {
+            get { return _clrName; }
+            set { _clrName = value.Replace("$", "S"); }
+        }
+
         public bool IsCLRPropertyGetter { get; set; }
         public bool IsCLRPropertySetter { get; set; }
         public bool IsCLRPropertyAdd { get; set; }


### PR DESCRIPTION
Fixed CLRName. $ sign is allowed in Java for  but not allowed in C#. Replaced by S (They looks like pretty similar)
according to
Java: http://docs.oracle.com/javase/specs/jls/se7/html/jls-3.html#jls-3.8
C#: https://msdn.microsoft.com/en-us/library/aa664670(v=vs.71).aspx