### PR TITLE
fix transient field processing

### DIFF
--- a/jni4net.proxygen/src/model/Repository.JVM.cs
+++ b/jni4net.proxygen/src/model/Repository.JVM.cs
@@ -460,7 +460,7 @@ namespace net.sf.jni4net.proxygen.model
             {
                 res.Attributes |= MemberAttributes.Final;
             }
-            if ((modifiers & (ModifierFlags.Varargs)) != ModifierFlags.None)
+            if (!res.IsField && (modifiers & (ModifierFlags.Varargs)) != ModifierFlags.None)
             {
                 var indexOfLastParameter = res.Parameters.Count - 1;
                 res.Parameters[indexOfLastParameter].IsOptional = true;


### PR DESCRIPTION
Method attribute VARARGS and field attribute TRANSIENT have same value (0x80)
VARARGS should be tested only for methods