### PR TITLE
WrapCLR makes more specific jvm proxy

### DIFF
--- a/jni4net.n/src/Bridge.CLR.convertor.cs
+++ b/jni4net.n/src/Bridge.CLR.convertor.cs
@@ -53,9 +53,10 @@ namespace net.sf.jni4net
 
             RegistryRecord record = Registry.GetCLRRecord(type);
             JniLocalHandle jvmProxy = record.CreateJVMProxy(env, obj);
-            return (Object)__IClrProxy.CreateProxy(env, jvmProxy);
-        }
 
+            return (Object)record.CreateCLRProxy(env, jvmProxy);
+        }
+        
         public static TRes UnwrapCLR<TRes>(Object obj)
         {
             var clrProxy = obj as IClrProxy;


### PR DESCRIPTION
This way itt can be used directly as parameter for jvm methods.
e.g. implement Java interface, create proxy and pass it as parameter to java method.
Useful for making global ref to java  java GC from collection ClrProxy
